### PR TITLE
Add `byte[]` type in Property.Types

### DIFF
--- a/Tree/Property.cs
+++ b/Tree/Property.cs
@@ -73,6 +73,7 @@ namespace RobloxFiles
             { typeof(float),   PropertyType.Float  },
             { typeof(double),  PropertyType.Double },
             { typeof(string),  PropertyType.String },
+            { typeof(byte[]),  PropertyType.String },
 
             { typeof(Ray),       PropertyType.Ray      },
             { typeof(Rect),      PropertyType.Rect     },


### PR DESCRIPTION
Simply added `byte[]` in `Property.Types`.

This adds support for `byte[]` property type when serializing `PROP` chunk of `BinaryRobloxFile`.

So now `BinaryStringValue.Value` can be serialized properly(maybe? but I have tested with `rbx-dom` with `Rojo` and `Lune`)

But needs XML token for `byte[]` to be serialized properly for `XMLRobloxFile`. (They're needed to be encoded to Base64 with CDATA prefix iirc)