### PR TITLE
Make BrickColor de/serialized in untransformed integers

### DIFF
--- a/BinaryFormat/BinaryFileReader.cs
+++ b/BinaryFormat/BinaryFileReader.cs
@@ -48,11 +48,6 @@ namespace RobloxFiles.BinaryFormat
             return (int)((uint)value >> 1) ^ (-(value & 1));
         }
 
-        public int Int32WithoutRotate(byte[] buffer, int startIndex)
-        {
-            return BitConverter.ToInt32(buffer, startIndex);
-        }
-
         // Rotates the sign bit of an int64 buffer.
         public long RotateInt64(byte[] buffer, int startIndex)
         {


### PR DESCRIPTION
According to [this](https://dom.rojo.space/binary.html#brickcolor), BrickColor must be **untransformed**.

However, Roblox-File-Format writes BrickColor as a transformed integer, which causes rbx-dom and Roblox Studio to read BrickColor values ​​that are not expected.

Causes following error in lune(which uses rbx-dom):
```
Failed to read document from buffer - Invalid property data: Property SpawnLocation.TeamColor was expected to be a valid BrickColor, but it was 388
```
Because of Roblox-File-Format's integer transformation for BrickColors, A BrickColor number Medium stone grey(194) is being written as 388(invalid BrickColor)

This PR fixes the BrickColor binary data corruption by making BrickColor de/serialized in untransformed integers.

~~The modified code has been formatted using CSharpier.~~